### PR TITLE
Reimplement server.Error for composite handlers

### DIFF
--- a/pkg/server/error.go
+++ b/pkg/server/error.go
@@ -1,0 +1,32 @@
+// Copyright 2024 SeatGeek, Inc.
+//
+// Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
+
+package server
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Error is a custom error type that includes an HTTP status code
+type Error struct {
+	Code   int
+	Reason error
+}
+
+func (h *Error) Error() string {
+	if h.Reason != nil {
+		return fmt.Sprintf("internal %d: %v", h.Code, h.Reason.Error())
+	}
+	return fmt.Sprintf("internal %d: something happened, perhaps", h.Code)
+}
+
+func (h *Error) Is(target error) bool {
+	var err *Error
+	if ok := errors.As(target, &err); !ok {
+		return false
+	}
+
+	return err.Code == h.Code && (errors.Is(err.Reason, h.Reason) || err.Reason.Error() == h.Reason.Error())
+}

--- a/pkg/server/error_test.go
+++ b/pkg/server/error_test.go
@@ -1,0 +1,98 @@
+// Copyright 2024 SeatGeek, Inc.
+//
+// Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
+
+package server
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestError_Error(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  *Error
+		want string
+	}{
+		{
+			name: "with reason",
+			err:  &Error{Code: 403, Reason: errors.New("forbidden")},
+			want: "internal 403: forbidden",
+		},
+		{
+			name: "without reason",
+			err:  &Error{Code: 403},
+			want: "internal 403: something happened, perhaps",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, tt.err.Error())
+		})
+	}
+}
+
+func TestError_Is(t *testing.T) {
+	t.Parallel()
+
+	target := &Error{Code: 403, Reason: errors.New("forbidden")}
+
+	tests := []struct {
+		name  string
+		other error
+		want  bool
+	}{
+		{
+			name:  "exact same object",
+			other: target,
+			want:  true,
+		},
+		{
+			name:  "different object, same values",
+			other: &Error{Code: 403, Reason: errors.New("forbidden")},
+			want:  true,
+		},
+		{
+			name:  "different code",
+			other: &Error{Code: 400, Reason: errors.New("forbidden")},
+			want:  false,
+		},
+		{
+			name:  "different reason",
+			other: &Error{Code: 403, Reason: errors.New("not allowed")},
+			want:  false,
+		},
+		{
+			name:  "different type",
+			other: errors.New("forbidden"),
+			want:  false,
+		},
+		{
+			name:  "wrapped",
+			other: fmt.Errorf("wrapped: %w", target),
+			want:  true,
+		},
+		{
+			name:  "inner reason",
+			other: target.Reason,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, errors.Is(target, tt.other))
+		})
+	}
+}

--- a/pkg/server/handler_test.go
+++ b/pkg/server/handler_test.go
@@ -50,6 +50,14 @@ func TestHandler(t *testing.T) {
 			wantStatusCode: 500,
 		},
 		{
+			name: "parse error with custom HTTP status code",
+			handler: handlerThatReturns(t, nil, &Error{
+				Code:   400,
+				Reason: someError,
+			}),
+			wantStatusCode: 400,
+		},
+		{
 			name:           "notifier error",
 			handler:        handlerThatReturns(t, someNotifications, nil),
 			notifier:       notifierThatReturns(t, someError),


### PR DESCRIPTION
This partially reverts 4652fa24ab0659519329de60e8f0bf6451580e30 because we _do_ want this helper, but only for composite handlers.