### PR TITLE
Update module github.com/cenkalti/backoff/v4 to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/seatgeek/mailroom
 
-go 1.22.3
+go 1.23
+
+toolchain go1.23.4
 
 require (
-	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff/v5 v5.0.0
 	github.com/go-playground/webhooks/v6 v6.4.0
 	github.com/google/uuid v1.6.0
 	github.com/lmittmann/tint v1.0.6
@@ -18,6 +20,7 @@ require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/containerd/containerd v1.7.18 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,10 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.0 h1:4ziwFuaVJicDO1ah1Nz1aXXV1caM28PFgf1V5TTFXew=
+github.com/cenkalti/backoff/v5 v5.0.0/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/containerd/containerd v1.7.18 h1:jqjZTQNfXGoEaZdW1WwPU0RqSn1Bm2Ay/KJPUuO8nao=
 github.com/containerd/containerd v1.7.18/go.mod h1:IYEk9/IO6wAPUz2bCMVUbsfXjzw5UNP5fLz4PsUygQ4=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=

--- a/internal/example.go
+++ b/internal/example.go
@@ -100,7 +100,9 @@ func main() {
 			//		5*time.Second,
 			//	),
 			//	3,
-			//	backoff.WithMaxElapsedTime(30*time.Second),
+			//	func() notifier.BackOff {
+			//		return backoff.NewExponentialBackOff()
+			//	},
 			// ),
 		),
 		mailroom.WithUserStore(

--- a/pkg/notifier/conventions.go
+++ b/pkg/notifier/conventions.go
@@ -8,7 +8,7 @@ package notifier
 import (
 	"context"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/seatgeek/mailroom/pkg/common"
 )
 

--- a/pkg/notifier/decorators.go
+++ b/pkg/notifier/decorators.go
@@ -42,13 +42,14 @@ func (w *withTimeout) Validate(ctx context.Context) error {
 }
 
 type BackOff = backoff.BackOff
+type BackOffFactory = func() BackOff
 
 // WithRetry decorates the given Transport with retry logic using the provided backoff
-func WithRetry(transport Transport, maxTries uint, backoffProvider func() BackOff) Transport {
+func WithRetry(transport Transport, maxTries uint, backoffFactory BackOffFactory) Transport {
 	return &withRetry{
 		Transport: transport,
 		maxTries:  maxTries,
-		backoff:   backoffProvider,
+		backoff:   backoffFactory,
 	}
 }
 

--- a/pkg/notifier/decorators_test.go
+++ b/pkg/notifier/decorators_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/seatgeek/mailroom/pkg/common"
 	"github.com/seatgeek/mailroom/pkg/event"
 	"github.com/seatgeek/mailroom/pkg/identifier"

--- a/pkg/notifier/decorators_test.go
+++ b/pkg/notifier/decorators_test.go
@@ -56,6 +56,10 @@ func TestWithRetry(t *testing.T) {
 		Type: "test",
 	}).Build()
 
+	err1 := errors.New("err 1")
+	err2 := errors.New("err 2")
+	err3 := errors.New("err 3")
+
 	tests := []struct {
 		name         string
 		maxRetries   uint64
@@ -76,7 +80,7 @@ func TestWithRetry(t *testing.T) {
 			name:       "one error",
 			maxRetries: 2,
 			givenErrs: []error{
-				errors.New("test"),
+				err1,
 				nil,
 			},
 			wantAttempts: 2,
@@ -86,21 +90,21 @@ func TestWithRetry(t *testing.T) {
 			name:       "one permanent error",
 			maxRetries: 2,
 			givenErrs: []error{
-				notifier.Permanent(errors.New("test")),
+				notifier.Permanent(err1),
 			},
 			wantAttempts: 1,
-			wantErr:      errors.New("test"),
+			wantErr:      err1,
 		},
 		{
 			name:       "max attempts",
 			maxRetries: 2,
 			givenErrs: []error{
-				errors.New("err 1"),
-				errors.New("err 2"),
-				errors.New("err 3"),
+				err1,
+				err2,
+				err3,
 			},
 			wantAttempts: 3,
-			wantErr:      errors.New("err 3"),
+			wantErr:      err3,
 		},
 	}
 
@@ -124,7 +128,7 @@ func TestWithRetry(t *testing.T) {
 
 			err := wrapped.Push(context.Background(), fakeNotification)
 
-			assert.Equal(t, tc.wantErr, err, "Error should match")
+			assert.ErrorIs(t, err, tc.wantErr, "Error should match")
 		})
 	}
 }

--- a/pkg/notifier/decorators_test.go
+++ b/pkg/notifier/decorators_test.go
@@ -118,10 +118,8 @@ func TestWithRetry(t *testing.T) {
 				transport.EXPECT().Push(mock.Anything, mock.Anything).Return(givenErr).Once()
 			}
 
-			wrapped := notifier.WithRetry(transport, tc.maxRetries, func(b *backoff.ExponentialBackOff) {
-				b.InitialInterval = 1 * time.Millisecond
-				b.MaxInterval = 10 * time.Millisecond
-				b.MaxElapsedTime = 20 * time.Millisecond
+			wrapped := notifier.WithRetry(transport, tc.maxRetries, func() backoff.BackOff {
+				return backoff.NewConstantBackOff(10 * time.Millisecond)
 			})
 
 			assert.Equal(t, transport.Key(), wrapped.Key(), "Key should be the same")


### PR DESCRIPTION
Based on #28, but with some additional (breaking) changes to the signature of `notifier.WithRetry()` to fix compatibility with v5:

- The second parameter now specifies the total attempts (including the first), not just the retries
- The second parameter is now a `uint` instead of `uint64`
- The third parameter now allows any type of backoff to be used, not just exponential backoffs, by providing a factory method (instead of exponential backoff options)