### PR TITLE
don't require a user to be found in the store

### DIFF
--- a/pkg/notifier/default.go
+++ b/pkg/notifier/default.go
@@ -25,7 +25,11 @@ func (d *DefaultNotifier) Push(ctx context.Context, notification common.Notifica
 
 	recipientUser, err := d.userStore.Find(ctx, notification.Recipient())
 	if err != nil {
-		slog.Debug("failed to find user, will attempt to notify on provided identifiers", "id", notification.Context().ID, "user", notification.Recipient().String(), "error", err)
+		level := slog.LevelDebug
+		if !errors.Is(err, user.ErrUserNotFound) {
+			level = slog.LevelError
+		}
+		slog.Log(ctx, level, "failed to find user, will attempt to notify on provided identifiers", "id", notification.Context().ID, "user", notification.Recipient().String(), "error", err)
 	}
 
 	// The store may know of other identifiers for this user, so we merge those in

--- a/pkg/notifier/default.go
+++ b/pkg/notifier/default.go
@@ -27,7 +27,7 @@ func (d *DefaultNotifier) Push(ctx context.Context, notification common.Notifica
 	recipientUser, err := d.userStore.Find(ctx, notification.Recipient())
 	if err != nil {
 		if !errors.Is(err, user.ErrUserNotFound) {
-			return fmt.Errorf("failed to find user: %w", err)
+			return fmt.Errorf("failed to find recipient user: %w", err)
 		}
 		slog.DebugContext(ctx, "user doesn't exist in store, will attempt to notify on provided identifiers", "id", notification.Context().ID, "recipient", notification.Recipient().String())
 	}

--- a/pkg/notifier/default.go
+++ b/pkg/notifier/default.go
@@ -25,11 +25,11 @@ func (d *DefaultNotifier) Push(ctx context.Context, notification common.Notifica
 
 	recipientUser, err := d.userStore.Find(ctx, notification.Recipient())
 	if err != nil {
-		level := slog.LevelDebug
-		if !errors.Is(err, user.ErrUserNotFound) {
-			level = slog.LevelError
+		if errors.Is(err, user.ErrUserNotFound) {
+			slog.DebugContext(ctx, "user doesn't exist in store, will attempt to notify on provided identifiers", "id", notification.Context().ID, "recipient", notification.Recipient().String())
+		} else {
+			slog.ErrorContext(ctx, "failed to find user, will attempt to notify on provided identifiers", "id", notification.Context().ID, "recipient", notification.Recipient().String(), "error", err)
 		}
-		slog.Log(ctx, level, "failed to find user, will attempt to notify on provided identifiers", "id", notification.Context().ID, "user", notification.Recipient().String(), "error", err)
 	}
 
 	// The store may know of other identifiers for this user, so we merge those in

--- a/pkg/notifier/default_test.go
+++ b/pkg/notifier/default_test.go
@@ -77,11 +77,18 @@ func TestDefaultNotifier_Push(t *testing.T) {
 			},
 			wantSent: []wantSent{},
 		},
+		// unknown user gets opted in to all transports
 		{
 			name:         "unknown user",
 			notification: notificationFor("com.example.one", unknownUser),
-			wantSent:     []wantSent{},
-			wantErrs:     []error{user.ErrUserNotFound, user.ErrUserNotFound},
+			transports: []notifier.Transport{
+				&fakeTransport{key: "slack"},
+				&fakeTransport{key: "email"},
+			},
+			wantSent: []wantSent{
+				{event: "com.example.one", transport: "slack"},
+				{event: "com.example.one", transport: "email"},
+			},
 		},
 		{
 			name:         "transport fails",

--- a/pkg/notifier/default_test.go
+++ b/pkg/notifier/default_test.go
@@ -103,7 +103,6 @@ func TestDefaultNotifier_Push(t *testing.T) {
 				{event: "com.example.one", transport: "email"},
 			},
 		},
-		// store failure should not prevent notifications from being attempted
 		{
 			name:         "store failure",
 			notification: notificationFor("com.example.one", knownUser.Identifiers),

--- a/pkg/notifier/default_test.go
+++ b/pkg/notifier/default_test.go
@@ -28,11 +28,11 @@ type userStoreWithFindErr struct {
 	findErr error
 }
 
-func (u *userStoreWithFindErr) Find(_ context.Context, possibleIdentifiers identifier.Set) (*user.User, error) {
+func (u *userStoreWithFindErr) Find(ctx context.Context, possibleIdentifiers identifier.Set) (*user.User, error) {
 	if u.findErr != nil {
 		return nil, u.findErr
 	}
-	return u.Store.Find(context.Background(), possibleIdentifiers)
+	return u.Store.Find(ctx, possibleIdentifiers)
 }
 
 func TestDefaultNotifier_Push(t *testing.T) {


### PR DESCRIPTION
a recipient for a notification may come with enough identifiers to be successfully sent along to transports. e.g., i may have some generator code like the following:

```go
if isAVeryImportantEvent(event) {
	recipients = append(recipients, identifier.NewSet(
		identifier.New(Email, "redalert@example.com"),
		identifier.New(SlackID, redAlertSlackChannelID),
	))
}
```

this recipient has the identifiers needed for mailroom to send the notification to the desired email address & slack channel. no need to drop the notification because it doesn't map to a user in the store.