### PR TITLE
Allow notifying unknown users

### DIFF
--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -94,5 +94,9 @@ func WithPreferences(p Preferences) Option {
 
 // String returns a simple string representation of a User's identify (useful for logging)
 func (r *User) String() string {
+	if (r == nil) || (r.Identifiers == nil) {
+		return "<unknown>"
+	}
+
 	return r.Identifiers.String()
 }


### PR DESCRIPTION
Our default notifier currently fails if the recipient does not exist in the user store. However, that user store information is only used for two purposes:

1. To augment their identifier set with others we know about
2. To avoid sending notifications via methods they've explicitly opted-out of

But if the user doesn't exist we don't need to error - we can just make sane default decisions:

1. Augmentation: just do nothing (as if they existed in the user store with no other known identifiers)
2. Opt-out: assume they haven't opted-out (otherwise we'd have a record of that)

As a result, notifications sent to users who are unknown by the user store will always attempt to send.