### PR TITLE
Refactor preferences to allow custom defaults and chaining

### DIFF
--- a/pkg/notifier/default.go
+++ b/pkg/notifier/default.go
@@ -17,7 +17,7 @@ import (
 // DefaultNotifier is the default implementation of the Notifier interface
 type DefaultNotifier struct {
 	transports  []Transport
-	preferences preference.Preferences
+	preferences preference.Provider
 }
 
 func (d *DefaultNotifier) Push(ctx context.Context, notification event.Notification) error {
@@ -52,7 +52,7 @@ func (d *DefaultNotifier) Push(ctx context.Context, notification event.Notificat
 var _ Notifier = &DefaultNotifier{}
 
 // New creates a new DefaultNotifier
-func New(transports []Transport, preferences preference.Preferences) *DefaultNotifier {
+func New(transports []Transport, preferences preference.Provider) *DefaultNotifier {
 	return &DefaultNotifier{
 		transports:  transports,
 		preferences: preferences,

--- a/pkg/notifier/default.go
+++ b/pkg/notifier/default.go
@@ -11,25 +11,26 @@ import (
 	"log/slog"
 
 	"github.com/seatgeek/mailroom/pkg/event"
-	"github.com/seatgeek/mailroom/pkg/user"
+	"github.com/seatgeek/mailroom/pkg/notifier/preference"
 )
 
 // DefaultNotifier is the default implementation of the Notifier interface
 type DefaultNotifier struct {
-	userStore  user.Store
-	transports []Transport
+	transports  []Transport
+	preferences preference.Preferences
 }
 
 func (d *DefaultNotifier) Push(ctx context.Context, notification event.Notification) error {
 	results := make([]error, 0, len(d.transports))
 
-	recipientUser := d.getRecipientUserForNotification(ctx, notification)
-
 	for _, transport := range d.transports {
-		// todo: should a processor handle this instead?
-		if recipientUser != nil && !recipientUser.Wants(notification.Context().Type, transport.Key()) {
-			slog.DebugContext(ctx, "user does not want this notification via this transport", "id", notification.Context().ID, "recipient", recipientUser.String(), "transport", transport.Key())
-			continue
+		wants := d.preferences.Wants(ctx, notification, transport.Key())
+		if wants == nil {
+			slog.DebugContext(ctx, "no explicit preference for notification; sending anyway", "id", notification.Context().ID, "type", notification.Context().Type, "recipient", notification.Recipient().String(), "transport", transport.Key())
+			// No explicit preference, we assume the user wants it
+		} else if !*wants {
+			slog.DebugContext(ctx, "user does not want this notification via this transport", "id", notification.Context().ID, "type", notification.Context().Type, "recipient", notification.Recipient().String(), "transport", transport.Key())
+			continue // User does not want this transport
 		}
 
 		slog.InfoContext(ctx, "pushing notification to transport", "id", notification.Context().ID, "type", notification.Context().Type, "recipient", notification.Recipient().String(), "transport", transport.Key())
@@ -48,28 +49,12 @@ func (d *DefaultNotifier) Push(ctx context.Context, notification event.Notificat
 	return errors.Join(results...)
 }
 
-func (d *DefaultNotifier) getRecipientUserForNotification(ctx context.Context, notification event.Notification) *user.User {
-	if d.userStore == nil {
-		return nil
-	}
-
-	usr, err := d.userStore.Find(ctx, notification.Recipient())
-	if err == nil {
-		return usr
-	}
-	if !errors.Is(err, user.ErrUserNotFound) {
-		slog.WarnContext(ctx, "failed to find user for preference lookup (will proceed without specific prefs)", "recipient", notification.Recipient().String(), "error", err)
-	}
-
-	return nil
-}
-
 var _ Notifier = &DefaultNotifier{}
 
 // New creates a new DefaultNotifier
-func New(userStore user.Store, transports ...Transport) *DefaultNotifier {
+func New(transports []Transport, preferences preference.Preferences) *DefaultNotifier {
 	return &DefaultNotifier{
-		userStore:  userStore,
-		transports: transports,
+		transports:  transports,
+		preferences: preferences,
 	}
 }

--- a/pkg/notifier/preference/preference.go
+++ b/pkg/notifier/preference/preference.go
@@ -12,22 +12,22 @@ import (
 	"github.com/seatgeek/mailroom/pkg/validation"
 )
 
-// Preferences provides a mechanism for determining whether a user wants to receive some notification via some transport.
-type Preferences interface {
+// Provider provides a mechanism for determining whether a user wants to receive some notification via some transport.
+type Provider interface {
 	// Wants returns whether the user wants to receive the given event via the given transport.
 	// It returns nil if there is no explicit preference.
 	Wants(context.Context, event.Notification, event.TransportKey) *bool
 }
 
-// Func is a function type that implements the Preferences interface.
+// Func is a function type that implements the Provider interface.
 type Func func(context.Context, event.Notification, event.TransportKey) *bool
 
 func (f Func) Wants(ctx context.Context, notification event.Notification, transport event.TransportKey) *bool {
 	return f(ctx, notification, transport)
 }
 
-// Chain is a sequence of Preferences that will be checked in order until one returns a non-nil value.
-type Chain []Preferences
+// Chain is a sequence of Provider instances that will be checked in order until one returns a non-nil value.
+type Chain []Provider
 
 var _ validation.Validator = (*Chain)(nil)
 
@@ -76,7 +76,7 @@ func (p Map) Wants(_ context.Context, notification event.Notification, transport
 	return nil
 }
 
-// Default returns a Preferences implementation that always returns the given boolean value.
+// Default returns a Provider implementation that always returns the given boolean value.
 func Default(wants bool) Func {
 	return func(_ context.Context, _ event.Notification, _ event.TransportKey) *bool {
 		return &wants

--- a/pkg/notifier/preference/preference.go
+++ b/pkg/notifier/preference/preference.go
@@ -1,0 +1,84 @@
+// Copyright 2025 SeatGeek, Inc.
+//
+// Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
+
+package preference
+
+import (
+	"context"
+	"errors"
+
+	"github.com/seatgeek/mailroom/pkg/event"
+	"github.com/seatgeek/mailroom/pkg/validation"
+)
+
+// Preferences provides a mechanism for determining whether a user wants to receive some notification via some transport.
+type Preferences interface {
+	// Wants returns whether the user wants to receive the given event via the given transport.
+	// It returns nil if there is no explicit preference.
+	Wants(context.Context, event.Notification, event.TransportKey) *bool
+}
+
+// Func is a function type that implements the Preferences interface.
+type Func func(context.Context, event.Notification, event.TransportKey) *bool
+
+func (f Func) Wants(ctx context.Context, notification event.Notification, transport event.TransportKey) *bool {
+	return f(ctx, notification, transport)
+}
+
+// Chain is a sequence of Preferences that will be checked in order until one returns a non-nil value.
+type Chain []Preferences
+
+var _ validation.Validator = (*Chain)(nil)
+
+func (c Chain) Wants(ctx context.Context, notification event.Notification, transport event.TransportKey) *bool {
+	for _, pref := range c {
+		if result := pref.Wants(ctx, notification, transport); result != nil {
+			return result
+		}
+	}
+
+	// If no preferences matched, return nil to indicate no explicit preference.
+	return nil
+}
+
+func (c Chain) Validate(ctx context.Context) error {
+	errs := make([]error, 0, len(c))
+	for _, pref := range c {
+		if v, ok := pref.(validation.Validator); ok {
+			if err := v.Validate(ctx); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// Map defines preferences by event type and transport.
+// For example, a user may want to receive PR review request notifications via Slack but not email.
+type Map map[event.Type]map[event.TransportKey]bool
+
+func (p Map) Wants(_ context.Context, notification event.Notification, transport event.TransportKey) *bool {
+	eventType := notification.Context().Type
+
+	if _, exists := p[eventType]; !exists {
+		// No preference set for this event
+		return nil
+	}
+
+	if want, exists := p[eventType][transport]; exists {
+		return &want
+	}
+
+	// No preference set for this transport
+	return nil
+}
+
+// Default returns a Preferences implementation that always returns the given boolean value.
+func Default(wants bool) Func {
+	return func(_ context.Context, _ event.Notification, _ event.TransportKey) *bool {
+		return &wants
+	}
+}

--- a/pkg/notifier/preference/preference_test.go
+++ b/pkg/notifier/preference/preference_test.go
@@ -1,0 +1,233 @@
+// Copyright 2025 SeatGeek, Inc.
+//
+// Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
+
+package preference_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/seatgeek/mailroom/pkg/event"
+	"github.com/seatgeek/mailroom/pkg/notifier/preference"
+	"github.com/seatgeek/mailroom/pkg/validation"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChain_Wants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		chain preference.Chain
+		want  *bool
+	}{
+		{
+			name:  "empty chain",
+			chain: preference.Chain{},
+			want:  nil,
+		},
+		{
+			name: "return Deliver if first preference returns true",
+			chain: preference.Chain{
+				preference.Default(true),
+				preference.Default(false),
+			},
+			want: ptrTo(true),
+		},
+		{
+			name: "return DoNotDeliver if first preference returns false",
+			chain: preference.Chain{
+				preference.Default(false),
+				preference.Default(true),
+			},
+			want: ptrTo(false),
+		},
+		{
+			name: "fallback to next preference if first returns nil",
+			chain: preference.Chain{
+				preference.Func(func(context.Context, event.Notification, event.TransportKey) *bool {
+					return nil
+				}),
+				preference.Default(true),
+			},
+			want: ptrTo(true),
+		},
+		{
+			name: "return nil if no preferences match",
+			chain: preference.Chain{
+				preference.Func(func(context.Context, event.Notification, event.TransportKey) *bool {
+					return nil
+				}),
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.chain.Wants(t.Context(), event.NewMockNotification(t), "some-transport-key")
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestChain_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		chain   preference.Chain
+		wantErr string
+	}{
+		{
+			name:    "empty chain is valid",
+			chain:   preference.Chain{},
+			wantErr: "",
+		},
+		{
+			name: "all preferences valid",
+			chain: preference.Chain{
+				preferenceThatValidates{},
+				preferenceThatValidates{},
+			},
+			wantErr: "",
+		},
+		{
+			name: "some preferences invalid",
+			chain: preference.Chain{
+				preferenceThatValidates{err: errors.New("first preference invalid")},
+				preferenceThatValidates{},
+				preferenceThatValidates{err: errors.New("third preference invalid")},
+			},
+			wantErr: "first preference invalid\nthird preference invalid",
+		},
+		{
+			name: "all preferences invalid",
+			chain: preference.Chain{
+				preferenceThatValidates{err: errors.New("first preference invalid")},
+				preferenceThatValidates{err: errors.New("second preference invalid")},
+			},
+			wantErr: "first preference invalid\nsecond preference invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.chain.Validate(t.Context())
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+type preferenceThatValidates struct {
+	err error
+}
+
+var (
+	_ preference.Preferences = preferenceThatValidates{}
+	_ validation.Validator   = preferenceThatValidates{}
+)
+
+func (p preferenceThatValidates) Wants(_ context.Context, _ event.Notification, _ event.TransportKey) *bool {
+	return nil
+}
+
+func (p preferenceThatValidates) Validate(_ context.Context) error {
+	return p.err
+}
+
+func TestMap(t *testing.T) {
+	t.Parallel()
+
+	prefMap := preference.Map{
+		"some-event-type": {
+			"slack": true,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		eventType event.Type
+		transport event.TransportKey
+		want      *bool
+	}{
+		{
+			name:      "event type and transport are defined",
+			eventType: "some-event-type",
+			transport: "slack",
+			want:      ptrTo(true),
+		},
+		{
+			name:      "event type defined, transport not defined",
+			eventType: "some-event-type",
+			transport: "email",
+			want:      nil,
+		},
+		{
+			name:      "event type not defined",
+			eventType: "another-event-type",
+			transport: "slack",
+			want:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			eventContext := event.Context{
+				Type: tt.eventType,
+			}
+
+			notification := event.NewMockNotification(t)
+			notification.EXPECT().Context().Return(eventContext).Maybe()
+
+			got := prefMap.Wants(t.Context(), notification, tt.transport)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		value bool
+		want  *bool
+	}{
+		{
+			value: true,
+			want:  ptrTo(true),
+		},
+		{
+			value: false,
+			want:  ptrTo(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("returns %v", tt.value), func(t *testing.T) {
+			t.Parallel()
+
+			pref := preference.Default(tt.value)
+			got := pref.Wants(t.Context(), event.NewMockNotification(t), "some-transport-key")
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
+}

--- a/pkg/notifier/preference/preference_test.go
+++ b/pkg/notifier/preference/preference_test.go
@@ -136,8 +136,8 @@ type preferenceThatValidates struct {
 }
 
 var (
-	_ preference.Preferences = preferenceThatValidates{}
-	_ validation.Validator   = preferenceThatValidates{}
+	_ preference.Provider  = preferenceThatValidates{}
+	_ validation.Validator = preferenceThatValidates{}
 )
 
 func (p preferenceThatValidates) Wants(_ context.Context, _ event.Notification, _ event.TransportKey) *bool {

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -24,11 +24,11 @@ type PreferencesHandler struct {
 	userStore  Store
 	parsers    map[string]event.Parser
 	transports []event.TransportKey
-	defaults   preference.Preferences
+	defaults   preference.Provider
 }
 
 // NewPreferencesHandler creates a new PreferencesHandler for managing user preferences
-func NewPreferencesHandler(userStore Store, parsers map[string]event.Parser, transports []event.TransportKey, defaults preference.Preferences) *PreferencesHandler {
+func NewPreferencesHandler(userStore Store, parsers map[string]event.Parser, transports []event.TransportKey, defaults preference.Provider) *PreferencesHandler {
 	return &PreferencesHandler{
 		userStore:  userStore,
 		parsers:    parsers,
@@ -101,7 +101,7 @@ func (ph *PreferencesHandler) UpdatePreferences(writer http.ResponseWriter, requ
 // Only event types and transports that are currently active in the server will
 // be included in the preference map. User is opted in to any preference that is
 // not stored.
-func (ph *PreferencesHandler) buildCurrentUserPreferences(ctx context.Context, p preference.Preferences) preference.Map {
+func (ph *PreferencesHandler) buildCurrentUserPreferences(ctx context.Context, p preference.Provider) preference.Map {
 	hydratedPreferences := make(preference.Map)
 
 	for _, src := range ph.parsers {

--- a/pkg/user/identifier_enrichment_test.go
+++ b/pkg/user/identifier_enrichment_test.go
@@ -33,7 +33,7 @@ func TestIdentifierEnrichmentProcessor_Process(t *testing.T) {
 		{
 			name: "user found and identifiers merged",
 			notifications: []event.Notification{
-				notificationFor(identifier.NewSet(id1)),
+				notificationFor("some-event", identifier.NewSet(id1)),
 			},
 			mockStoreSetup: func(mockStore *user.MockStore) {
 				foundUser := user.New("test-user", user.WithIdentifier(id2), user.WithIdentifier(id3))
@@ -48,10 +48,10 @@ func TestIdentifierEnrichmentProcessor_Process(t *testing.T) {
 		{
 			name: "multiple notifications with mixed results",
 			notifications: []event.Notification{
-				notificationFor(identifier.NewSet(id1)),
-				notificationFor(nil),
-				notificationFor(identifier.NewSet(id2)),
-				notificationFor(identifier.NewSet(id3)),
+				notificationFor("some-event", identifier.NewSet(id1)),
+				notificationFor("some-event", nil),
+				notificationFor("some-event", identifier.NewSet(id2)),
+				notificationFor("some-event", identifier.NewSet(id3)),
 			},
 			mockStoreSetup: func(mockStore *user.MockStore) {
 				foundUser := user.New("test-user-1", user.WithIdentifier(identifier.New("new", "val1")))
@@ -72,7 +72,7 @@ func TestIdentifierEnrichmentProcessor_Process(t *testing.T) {
 		{
 			name: "recipient is nil",
 			notifications: []event.Notification{
-				notificationFor(nil),
+				notificationFor("some-event", nil),
 			},
 			expect: func(t *testing.T, result []event.Notification) {
 				t.Helper()
@@ -91,7 +91,7 @@ func TestIdentifierEnrichmentProcessor_Process(t *testing.T) {
 		{
 			name: "user not found",
 			notifications: []event.Notification{
-				notificationFor(identifier.NewSet(id1)),
+				notificationFor("some-event", identifier.NewSet(id1)),
 			},
 			mockStoreSetup: func(mockStore *user.MockStore) {
 				mockStore.On("Find", t.Context(), identifier.NewSet(id1)).Return(nil, user.ErrUserNotFound).Once()
@@ -105,7 +105,7 @@ func TestIdentifierEnrichmentProcessor_Process(t *testing.T) {
 		{
 			name: "error finding user",
 			notifications: []event.Notification{
-				notificationFor(identifier.NewSet(id1)),
+				notificationFor("some-event", identifier.NewSet(id1)),
 			},
 			mockStoreSetup: func(mockStore *user.MockStore) {
 				mockStore.On("Find", t.Context(), identifier.NewSet(id1)).Return(nil, errors.New("some db error")).Once()
@@ -147,26 +147,4 @@ func TestNewIdentifierEnrichmentProcessor_NilStore(t *testing.T) {
 	assert.PanicsWithValue(t, "user.Store cannot be nil for IdentifierEnrichmentProcessor", func() {
 		user.NewIdentifierEnrichmentProcessor(nil)
 	})
-}
-
-func notificationFor(id identifier.Set) event.Notification {
-	return &fakeNotification{
-		recipient: id,
-	}
-}
-
-type fakeNotification struct {
-	recipient identifier.Set
-}
-
-func (f *fakeNotification) Context() event.Context {
-	return event.Context{}
-}
-
-func (f *fakeNotification) Render(_ event.TransportKey) string {
-	return "some message"
-}
-
-func (f *fakeNotification) Recipient() identifier.Set {
-	return f.recipient
 }

--- a/pkg/user/postgres/store.go
+++ b/pkg/user/postgres/store.go
@@ -11,14 +11,15 @@ import (
 	"time"
 
 	"github.com/seatgeek/mailroom/pkg/identifier"
+	"github.com/seatgeek/mailroom/pkg/notifier/preference"
 	"github.com/seatgeek/mailroom/pkg/user"
 	"gorm.io/gorm"
 )
 
 // UserModel is the gorm model for a user
 type UserModel struct {
-	Key         string           `gorm:"primarykey"`
-	Preferences user.Preferences `gorm:"serializer:json"`
+	Key         string         `gorm:"primarykey"`
+	Preferences preference.Map `gorm:"serializer:json"`
 
 	// Identifiers is a map of all identifiers for the user
 	Identifiers map[identifier.NamespaceAndKind]string `gorm:"serializer:json"`
@@ -154,7 +155,7 @@ func (s *Store) GetByIdentifier(ctx context.Context, id identifier.Identifier) (
 }
 
 // SetPreferences implements user.Store.
-func (s *Store) SetPreferences(ctx context.Context, key string, prefs user.Preferences) error {
+func (s *Store) SetPreferences(ctx context.Context, key string, prefs preference.Map) error {
 	return s.db.WithContext(ctx).Model(&UserModel{}).Where("key = ?", key).Update("preferences", prefs).Error
 }
 

--- a/pkg/user/postgres/store_test.go
+++ b/pkg/user/postgres/store_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/seatgeek/mailroom/pkg/identifier"
+	"github.com/seatgeek/mailroom/pkg/notifier/preference"
 	"github.com/seatgeek/mailroom/pkg/user"
 	"github.com/seatgeek/mailroom/pkg/user/postgres"
 	"github.com/stretchr/testify/assert"
@@ -295,7 +296,7 @@ func TestPostgresStore_SetPreferences(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Set preferences
-	expectedPreferences := user.Preferences{
+	expectedPreferences := preference.Map{
 		"com.example.notification": {
 			"email": true,
 			"slack": false,

--- a/pkg/user/preferences.go
+++ b/pkg/user/preferences.go
@@ -1,0 +1,51 @@
+// Copyright 2025 SeatGeek, Inc.
+//
+// Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
+
+package user
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/seatgeek/mailroom/pkg/event"
+	"github.com/seatgeek/mailroom/pkg/notifier/preference"
+)
+
+type PreferenceProvider struct {
+	userStore Store
+}
+
+var _ preference.Preferences = (*PreferenceProvider)(nil)
+
+func NewPreferenceProvider(userStore Store) *PreferenceProvider {
+	return &PreferenceProvider{
+		userStore: userStore,
+	}
+}
+
+func (p PreferenceProvider) Wants(ctx context.Context, notification event.Notification, transport event.TransportKey) *bool {
+	recipientUser := p.getRecipientUserForNotification(ctx, notification)
+	if recipientUser == nil {
+		return nil
+	}
+
+	return recipientUser.Preferences.Wants(ctx, notification, transport)
+}
+
+func (p PreferenceProvider) getRecipientUserForNotification(ctx context.Context, notification event.Notification) *User {
+	if p.userStore == nil {
+		return nil
+	}
+
+	usr, err := p.userStore.Find(ctx, notification.Recipient())
+	if err == nil {
+		return usr
+	}
+	if !errors.Is(err, ErrUserNotFound) {
+		slog.WarnContext(ctx, "failed to find user for preference lookup", "recipient", notification.Recipient().String(), "error", err)
+	}
+
+	return nil
+}

--- a/pkg/user/preferences.go
+++ b/pkg/user/preferences.go
@@ -17,7 +17,7 @@ type PreferenceProvider struct {
 	userStore Store
 }
 
-var _ preference.Preferences = (*PreferenceProvider)(nil)
+var _ preference.Provider = (*PreferenceProvider)(nil)
 
 func NewPreferenceProvider(userStore Store) *PreferenceProvider {
 	return &PreferenceProvider{

--- a/pkg/user/preferences_test.go
+++ b/pkg/user/preferences_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 SeatGeek, Inc.
+//
+// Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
+
+package user_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/seatgeek/mailroom/pkg/event"
+	"github.com/seatgeek/mailroom/pkg/identifier"
+	"github.com/seatgeek/mailroom/pkg/notification"
+	"github.com/seatgeek/mailroom/pkg/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestPreferenceProvider_Wants(t *testing.T) {
+	t.Parallel()
+
+	someUser := user.New(
+		"rufus",
+		user.WithIdentifier(identifier.New(identifier.GenericUsername, "rufus")),
+		user.WithPreference("com.example.one", "slack", true),
+		user.WithPreference("com.example.two", "email", false),
+	)
+
+	tests := []struct {
+		name         string
+		notification event.Notification
+		transport    event.TransportKey
+		userStore    user.Store
+		wants        *bool
+	}{
+		{
+			name:         "known user; wants",
+			notification: notificationFor("com.example.one", someUser.Identifiers),
+			transport:    "slack",
+			userStore:    user.NewInMemoryStore(someUser),
+			wants:        ptrTo(true),
+		},
+		{
+			name:         "known user; does not want",
+			notification: notificationFor("com.example.two", someUser.Identifiers),
+			transport:    "email",
+			userStore:    user.NewInMemoryStore(someUser),
+			wants:        ptrTo(false),
+		},
+		{
+			name:         "known user; no preference",
+			notification: notificationFor("com.example.three", someUser.Identifiers),
+			transport:    "smoke-signal",
+			userStore:    user.NewInMemoryStore(someUser),
+			wants:        nil,
+		},
+		{
+			name:         "unknown user",
+			notification: notificationFor("com.example.one", someUser.Identifiers),
+			transport:    "email",
+			userStore:    user.NewInMemoryStore(), // empty store
+			wants:        nil,
+		},
+		{
+			name:         "no user store provided for some reason",
+			notification: notificationFor("com.example.one", someUser.Identifiers),
+			transport:    "email",
+			userStore:    nil,
+			wants:        nil, // should not panic, just return nil
+		},
+		{
+			name:         "user store returns error",
+			notification: notificationFor("com.example.one", someUser.Identifiers),
+			transport:    "email",
+			userStore:    userStoreThatErrors(t, errors.New("database connection error")),
+			wants:        nil, // should not panic, just return nil
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := user.NewPreferenceProvider(tt.userStore)
+
+			wants := provider.Wants(t.Context(), tt.notification, tt.transport)
+			assert.Equal(t, tt.wants, wants)
+		})
+	}
+}
+
+func notificationFor(eventType event.Type, identifiers identifier.Set) event.Notification {
+	return notification.NewBuilder(
+		event.Context{
+			ID:   event.ID(eventType),
+			Type: eventType,
+		}).
+		WithRecipient(identifiers).
+		WithDefaultMessage("hello world").
+		Build()
+}
+
+func ptrTo(b bool) *bool {
+	return &b
+}
+
+func userStoreThatErrors(t *testing.T, err error) user.Store {
+	t.Helper()
+
+	store := user.NewMockStore(t)
+	store.EXPECT().Find(mock.Anything, mock.Anything).Return(nil, err).Maybe()
+
+	return store
+}

--- a/pkg/user/store.go
+++ b/pkg/user/store.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/seatgeek/mailroom/pkg/identifier"
+	"github.com/seatgeek/mailroom/pkg/notifier/preference"
 )
 
 // ErrUserNotFound is returned when a user is not found in the Store.
@@ -35,7 +36,7 @@ type Store interface {
 	Find(ctx context.Context, possibleIdentifiers identifier.Set) (*User, error)
 
 	// SetPreferences replaces the preferences for a user by key
-	SetPreferences(ctx context.Context, key string, prefs Preferences) error
+	SetPreferences(ctx context.Context, key string, prefs preference.Map) error
 }
 
 // InMemoryStore is a simple in-memory implementation of the Store interface
@@ -108,7 +109,7 @@ func (s *InMemoryStore) Find(ctx context.Context, possibleIdentifiers identifier
 	return nil, ErrUserNotFound
 }
 
-func (s *InMemoryStore) SetPreferences(ctx context.Context, key string, prefs Preferences) error {
+func (s *InMemoryStore) SetPreferences(ctx context.Context, key string, prefs preference.Map) error {
 	u, err := s.Get(ctx, key)
 	if err != nil {
 		return err

--- a/pkg/user/store.go
+++ b/pkg/user/store.go
@@ -18,7 +18,7 @@ import (
 // we failed to locate a single known user in the store. Think of it like a 404 error.
 var ErrUserNotFound = errors.New("user not found")
 
-// Store is a database that stores user information, like Preferences and identifiers.
+// Store is a database that stores user information, like Provider and identifiers.
 // Implementations may be backed by a SQL database, an in-memory store, or something else.
 //
 // For all methods that search by identifier, the store MUST return the user that matches the identifier exactly.

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -8,29 +8,8 @@ package user
 import (
 	"github.com/seatgeek/mailroom/pkg/event"
 	"github.com/seatgeek/mailroom/pkg/identifier"
+	"github.com/seatgeek/mailroom/pkg/notifier/preference"
 )
-
-// Preferences define which events a user wants to receive, and via which transports.
-// For example, a user may want to receive PR review request notifications via Slack but not email.
-type Preferences map[event.Type]map[event.TransportKey]bool
-
-// Wants returns true if the user wants to receive the given event via the given transport.
-// We assume that all preferences are opt-out by default; in other words, if a user has no preference
-// for a given event, we assume they DO want it. We only return false if they have explicitly
-// said they do not want it (and have false set in the map).
-func (p Preferences) Wants(event event.Type, transport event.TransportKey) bool {
-	if _, exists := p[event]; !exists {
-		// No preference set for this event, so assume they want it.
-		return true
-	}
-
-	if want, exists := p[event][transport]; exists {
-		return want
-	}
-
-	// No preference set for this transport, so assume they want it.
-	return true
-}
 
 // User is somebody who may receive notifications and their preferences for receiving those.
 type User struct {
@@ -39,7 +18,7 @@ type User struct {
 	// Identifiers are unique attributes attached to a user that represent that user in the
 	// scope of external systems, e.g. a gitlab.com/id or a slack.com/id.
 	Identifiers identifier.Set
-	Preferences
+	Preferences preference.Map
 }
 
 // New creates a new User with the given options
@@ -47,7 +26,7 @@ func New(key string, options ...Option) *User {
 	u := &User{
 		Key:         key,
 		Identifiers: identifier.NewSet(),
-		Preferences: make(Preferences),
+		Preferences: make(preference.Map),
 	}
 
 	for _, opt := range options {
@@ -85,7 +64,7 @@ func WithPreference(evt event.Type, transport event.TransportKey, wants bool) Op
 }
 
 // WithPreferences sets all the Preferences for a User
-func WithPreferences(p Preferences) Option {
+func WithPreferences(p preference.Map) Option {
 	return func(u *User) {
 		u.Preferences = p
 	}

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -63,7 +63,7 @@ func WithPreference(evt event.Type, transport event.TransportKey, wants bool) Op
 	}
 }
 
-// WithPreferences sets all the Preferences for a User
+// WithPreferences sets all the Provider for a User
 func WithPreferences(p preference.Map) Option {
 	return func(u *User) {
 		u.Preferences = p

--- a/pkg/user/user_test.go
+++ b/pkg/user/user_test.go
@@ -7,8 +7,8 @@ package user
 import (
 	"testing"
 
-	"github.com/seatgeek/mailroom/pkg/event"
 	"github.com/seatgeek/mailroom/pkg/identifier"
+	"github.com/seatgeek/mailroom/pkg/notifier/preference"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,7 +29,7 @@ func TestNew(t *testing.T) {
 		identifier.New("email", "rufus@seatgeek.com"),
 	}
 
-	wantPreferences := Preferences{
+	wantPreferences := preference.Map{
 		"com.example.notification": {
 			"email": true,
 		},
@@ -37,59 +37,6 @@ func TestNew(t *testing.T) {
 
 	assert.ElementsMatch(t, wantIdentifiers, user.Identifiers.ToList())
 	assert.Equal(t, wantPreferences, user.Preferences)
-}
-
-func TestUser_Wants(t *testing.T) {
-	t.Parallel()
-
-	user := New(
-		"rufus",
-		WithPreferences(Preferences{
-			"com.example.notification": {
-				"email": true,
-				"slack": false,
-			},
-		}),
-	)
-
-	tests := []struct {
-		name      string
-		event     event.Type
-		transport event.TransportKey
-		expected  bool
-	}{
-		{
-			name:      "preference explicitly set to true",
-			event:     "com.example.notification",
-			transport: "email",
-			expected:  true,
-		},
-		{
-			name:      "preference explicitly set to false",
-			event:     "com.example.notification",
-			transport: "slack",
-			expected:  false,
-		},
-		{
-			name:      "preference not defined for transport",
-			event:     "com.example.notification",
-			transport: "smoke_signal",
-			expected:  true,
-		},
-		{
-			name:      "preference not defined for event",
-			event:     "com.example.other",
-			transport: "email",
-			expected:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.expected, user.Wants(tt.event, tt.transport))
-		})
-	}
 }
 
 func TestUser_String(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -28,7 +28,7 @@ type Server struct {
 	processors         []event.Processor
 	notifier           notifier.Notifier
 	transports         []notifier.Transport
-	defaultPreferences preference.Preferences
+	defaultPreferences preference.Provider
 	userStore          user.Store
 	router             *mux.Router
 }
@@ -101,7 +101,7 @@ func WithUserStore(us user.Store) Opt {
 }
 
 // WithDefaultPreferences sets the default preferences for the server
-func WithDefaultPreferences(prefs preference.Preferences) Opt {
+func WithDefaultPreferences(prefs preference.Provider) Opt {
 	return func(s *Server) {
 		s.defaultPreferences = prefs
 	}

--- a/server.go
+++ b/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/seatgeek/mailroom/pkg/event"
 	"github.com/seatgeek/mailroom/pkg/notifier"
+	"github.com/seatgeek/mailroom/pkg/notifier/preference"
 	"github.com/seatgeek/mailroom/pkg/server"
 	"github.com/seatgeek/mailroom/pkg/user"
 	"github.com/seatgeek/mailroom/pkg/validation"
@@ -22,13 +23,14 @@ import (
 // Server is the heart of the mailroom application
 // It listens for incoming webhooks, parses them, generates notifications, and dispatches them to users.
 type Server struct {
-	listenAddr string
-	parsers    map[string]event.Parser
-	processors []event.Processor
-	notifier   notifier.Notifier
-	transports []notifier.Transport
-	userStore  user.Store
-	router     *mux.Router
+	listenAddr         string
+	parsers            map[string]event.Parser
+	processors         []event.Processor
+	notifier           notifier.Notifier
+	transports         []notifier.Transport
+	defaultPreferences preference.Preferences
+	userStore          user.Store
+	router             *mux.Router
 }
 
 type Opt func(s *Server)
@@ -36,16 +38,20 @@ type Opt func(s *Server)
 // New returns a new server
 func New(opts ...Opt) *Server {
 	s := &Server{
-		listenAddr: "0.0.0.0:8000",
-		router:     mux.NewRouter(),
-		parsers:    make(map[string]event.Parser),
+		listenAddr:         "0.0.0.0:8000",
+		router:             mux.NewRouter(),
+		parsers:            make(map[string]event.Parser),
+		defaultPreferences: preference.Default(true),
 	}
 
 	for _, opt := range opts {
 		opt(s)
 	}
 
-	s.notifier = notifier.New(s.userStore, s.transports...)
+	s.notifier = notifier.New(s.transports, preference.Chain{
+		user.NewPreferenceProvider(s.userStore),
+		s.defaultPreferences,
+	})
 
 	return s
 }
@@ -94,6 +100,13 @@ func WithUserStore(us user.Store) Opt {
 	}
 }
 
+// WithDefaultPreferences sets the default preferences for the server
+func WithDefaultPreferences(prefs preference.Preferences) Opt {
+	return func(s *Server) {
+		s.defaultPreferences = prefs
+	}
+}
+
 // WithRouter sets the mux.Router used for the server
 func WithRouter(router *mux.Router) Opt {
 	return func(s *Server) {
@@ -132,6 +145,12 @@ func (s *Server) validate(ctx context.Context) error { //nolint:revive // high c
 		}
 	}
 
+	if v, ok := s.defaultPreferences.(validation.Validator); ok {
+		if err := v.Validate(ctx); err != nil {
+			return fmt.Errorf("default preferences failed to validate: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -161,7 +180,7 @@ func (s *Server) serveHttp(ctx context.Context) error {
 	}
 
 	// Expose routes for managing user preferences
-	prefs := user.NewPreferencesHandler(s.userStore, s.parsers, transportKeys(s.transports))
+	prefs := user.NewPreferencesHandler(s.userStore, s.parsers, transportKeys(s.transports), s.defaultPreferences)
 	hsm.HandleFunc("/users/{key}/preferences", prefs.GetPreferences).Methods("GET")
 	hsm.HandleFunc("/users/{key}/preferences", prefs.UpdatePreferences).Methods("PUT")
 	hsm.HandleFunc("/configuration", prefs.ListOptions).Methods("GET")

--- a/server_test.go
+++ b/server_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/seatgeek/mailroom/pkg/event"
 	"github.com/seatgeek/mailroom/pkg/identifier"
+	"github.com/seatgeek/mailroom/pkg/notifier/preference"
 	"github.com/seatgeek/mailroom/pkg/user"
 	"github.com/seatgeek/mailroom/pkg/validation"
 	"github.com/stretchr/testify/assert"
@@ -191,7 +192,7 @@ func (s userStoreThatFailsToValidate) Find(_ context.Context, _ identifier.Set) 
 	panic("not called in our tests")
 }
 
-func (s userStoreThatFailsToValidate) SetPreferences(_ context.Context, _ string, _ user.Preferences) error {
+func (s userStoreThatFailsToValidate) SetPreferences(_ context.Context, _ string, _ preference.Map) error {
 	panic("not called in our tests")
 }
 


### PR DESCRIPTION
This PR shifts responsibility for delivery preferences out of the user objects and into a customizeable, chainable system.

## Context

Previously, we assumed users should **always** receive notifications by default unless they explicitly opted-out. This makes sense in most cases, but there may be certain noisy notifications that should instead be opt-in. Ideally we'd have a way for Mailroom to determine whether to deliver based on checking the following things in the following order:

- User Preferences
  - (Has the user explicitly opted into or out of this notification?)
- Default Preferences
  - (Sane defaults optionally set by the developer per notification and/or transport type)
- Fallback Preference
  - (A global option if nothing above returned an explicit preference)

This PR makes that possible.

## Changes

Notable changes include:

- Added a new `pkg/notifier/preference` package with primitives for defining and checking preferences
- Abstracted per-user preference fetching into a new `user.PreferenceProvider`
- Added a new `mailroom.WithDefaultPreferences()` function to provide default preferences
  - The default notifier will check the `user.PreferenceProvider` first, falling back to the default preferences if needed'
  - Default preferences can be provided as a fixed value (via `preference.Default([bool])`), a custom function, a chain of preference providers, etc.