### PR TITLE
Notification Clone Uses Slices Clone for slackOpts 

### DIFF
--- a/pkg/notification/builder.go
+++ b/pkg/notification/builder.go
@@ -6,6 +6,7 @@ package notification
 
 import (
 	"maps"
+	"slices"
 
 	"github.com/seatgeek/mailroom/pkg/event"
 	"github.com/seatgeek/mailroom/pkg/identifier"
@@ -107,12 +108,6 @@ func (b *builderOpts) Clone() event.Notification {
 		recipients:          b.recipients.Copy(),
 		fallbackMessage:     b.fallbackMessage,
 		messagePerTransport: maps.Clone(b.messagePerTransport),
-		slackOpts:           copySlackOpts(b.slackOpts),
+		slackOpts:           slices.Clone(b.slackOpts),
 	}
-}
-
-func copySlackOpts(slackOpts []slack.MsgOption) []slack.MsgOption {
-	newOpts := make([]slack.MsgOption, len(slackOpts))
-	copy(newOpts, slackOpts)
-	return newOpts
 }


### PR DESCRIPTION
When cloning a Notification, use `slices.Clone` to clone the slackOpts.