### PR TITLE
Add event.ProcessorFunc()

### DIFF
--- a/pkg/event/types.go
+++ b/pkg/event/types.go
@@ -176,3 +176,9 @@ type Processor interface {
 	// for the first processor) and returns a potentially modified slice of notifications.
 	Process(ctx context.Context, evt Event, notifications []Notification) ([]Notification, error)
 }
+
+type ProcessorFunc func(ctx context.Context, evt Event, notifications []Notification) ([]Notification, error)
+
+func (f ProcessorFunc) Process(ctx context.Context, evt Event, notifications []Notification) ([]Notification, error) {
+	return f(ctx, evt, notifications)
+}


### PR DESCRIPTION
Processors consist of a single function, so let's make it easier to run a single function as a processor.